### PR TITLE
Ajouter un outil d'analytics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,32 +2,29 @@ sudo: false
 language: cpp
 
 env:
-  HUGO_FLAVOUR: hugo
-  HUGO_VERSION: "0.45"
-  PREPROD_URL: "https://cdsp-scpo.github.io/site-DIME-SHS/"
-  PROD_URL: "https://www.sciencespo.fr/dime-shs/"
+- TARGET_BRANCH=gh-pages
+  HUGO_FLAVOUR=hugo
+  HUGO_VERSION="0.45"
+  BASE_URL=https://cdsp-scpo.github.io/site-DIME-SHS/
+  MATOMO_SITE_ID=10
+- TARGET_BRANCH=prod
+  HUGO_FLAVOUR=hugo
+  HUGO_VERSION="0.45"
+  BASE_URL=https://www.sciencespo.fr/dime-shs/
+  MATOMO_SITE_ID=-1
 
 install:
 - wget --no-clobber https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${HUGO_FLAVOUR}_${HUGO_VERSION}_Linux-64bit.tar.gz
 - tar -xzf ${HUGO_FLAVOUR}_${HUGO_VERSION}_Linux-64bit.tar.gz
 - rm ${HUGO_FLAVOUR}_${HUGO_VERSION}_Linux-64bit.tar.gz
 
-script:
-- ./hugo -b $PREPROD_URL -d public/preprod
-- ./hugo -b $PROD_URL -d public/prod
+script: ./hugo -b $BASE_URL
 
 deploy:
 - provider: pages
   skip-cleanup: true
   github-token: "$GH_TOKEN"
-  local-dir: public/preprod
-  target-branch: gh-pages
-  on:
-    branch: master
-- provider: pages
-  skip-cleanup: true
-  github-token: "$GH_TOKEN"
-  local-dir: public/prod
-  target-branch: prod
+  local-dir: public
+  target-branch: $TARGET_BRANCH
   on:
     branch: master

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -31,6 +31,7 @@
 </section>
 {{ end }}
 
-{{ partial "footer.html" . }}
+{{ partialCached "footer.html" . }}
+{{ partialCached "stats.html" . }}
 </body>
 </html>

--- a/layouts/partials/stats.html
+++ b/layouts/partials/stats.html
@@ -1,0 +1,12 @@
+<script type="text/javascript">
+  var _paq = _paq || [];
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="//cdsp.sciences-po.fr/stats/";
+    _paq.push(['setTrackerUrl', u+'piwik.php']);
+    _paq.push(['setSiteId', {{ getenv "MATOMO_SITE_ID" | default 10 }}]);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>


### PR DESCRIPTION
Par défaut, le Google Analytics du site de Sciences-Po sinon un autre outil utilisé par le CDSP.

# Préprod/test 

```
<!-- Matomo -->
<script type="text/javascript">
  var _paq = _paq || [];
  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
  _paq.push(['trackPageView']);
  _paq.push(['enableLinkTracking']);
  (function() {
    var u="//cdsp.sciences-po.fr/stats/";
    _paq.push(['setTrackerUrl', u+'piwik.php']);
    _paq.push(['setSiteId', '10']);
    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
  })();
</script>
<!-- End Matomo Code -->
```