### PR TITLE
Ajustements footer

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -7,6 +7,40 @@ const $$ = (selector, root=document) => Array.from(root.querySelectorAll(selecto
 const toc = document.getElementById('TableOfContents');
 new menuspy(toc, {enableLocationHash: false});
 
+// scroll if anchor is targeted in a sticky context
+window.addEventListener('hashchange', (event) => {
+  const header = $('.site-header');
+
+  // element is sticky if it's at the top but far from the document top
+  if (header.offsetTop && header.clientTop === 0) {
+    window.scrollBy(0, header.offsetHeight * -1);
+  }
+});
+
+const slidesContainer = $('.slides');
+if (slidesContainer) {
+  const nav = $('.slides__nav > ul');
+  $$('.slide', slidesContainer).forEach((slide, i) => {
+    if (!slide.getAttribute('id')) {
+      slide.setAttribute('id', `slide:${i+1}`)
+    }
+    const id = slide.getAttribute('id');
+    const li = document.createElement('li');
+    li.innerHTML = `<a href="#${id}">${String(i+1)}</a>`;
+    if (i === 0) {
+      li.classList.add('active');
+    }
+    nav.appendChild(li);
+  });
+  new menuspy(nav, {
+    enableLocationHash: false,
+    // refElement: slidesContainer,
+    threshold: 75,
+    hashTimeout: 300,
+  });
+}
+
+
 // footnotes -> sidenotes
 $$('.footnotes').forEach(footnotes => {
   footnotes.setAttribute('hidden', true);

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -5,8 +5,8 @@
     <li class="navigation-item">
       {{- $Scratch := newScratch -}}
       {{- $Scratch.Set "url" .URL -}}
-      {{- if and (.HasChildren) (index .Children 0) (isset (index .Children 0) "Section") -}}
-      {{- $Scratch.Set "url" (index .Children 0).URL -}}">
+      {{- if and (.HasChildren) (ne .Page nil) (.Page.Section) -}}
+      {{- $Scratch.Set "url" (index .Children 0).URL -}}
       {{ end }}
       <a href="{{ $Scratch.Get "url" }}" class="navigation-item__headline">
         {{ .Title }}


### PR DESCRIPTION
1. les titres de rubriques tournent dans le vide :
- soit on envoie vers les premières pages de chaque rubrique (projet-> enjeux ; instruments->ELIPSS, et Productions->Enquêtes), 
- soit on rend ces intitulés non-cliquables.

2. L'ancre sur "présentation" renvoie au début du texte, ce serait possible de la caler sur l'écran?

refs #17 
fixes #31 
fixes #35