### PR TITLE
solution minimale fonctionnelle pour les notes.

### DIFF
--- a/assets/_markdown_styles.scss
+++ b/assets/_markdown_styles.scss
@@ -2,6 +2,10 @@
 @import 'components/lists';
 @import 'components/links';
 
+.footnote-ref {
+  @extend .ph1;
+}
+
 .columns {
   @extend .flex;
   justify-content: space-between;
@@ -29,9 +33,28 @@
     @extend .dn;
     @extend .db-ns;
     @extend .w-third-ns;
+    @extend .pt3;
 
     @extend .f6;
     @extend .mid-gray;
+
+    .sidenote {
+      @extend .lh-title;
+      @extend .mb3;
+      @extend .relative;
+
+      &[data-refnote]:before {
+        @extend sup;
+        content: attr(data-refnote);
+        @extend .absolute;
+        @extend .lh-title;
+        @extend .left--1;
+        @extend .top-0;
+
+        @extend .dark-red;
+        @extend .underline;
+      }
+    }
 
     .sidenote > ul,
     .sidenote > ol {
@@ -54,29 +77,6 @@
 .sidenote.in--sidenotes,
 .footnotes {
   @extend .dn-ns;
-}
-
-.in-sidebar {
-  @extend .f6;
-  @extend .mid-gray;
-
-  > ul,
-  > ol,
-  .article__body & > ul,
-  .article__body & > ol {
-    @extend .list-outside;
-    @extend .pl3;
-  }
-
-  a {
-    @extend .link-arrow;
-    @extend .pv1;
-    @extend .toggle-u-nou;
-  }
-
-  .footnote-return {
-    display: none;
-  }
 }
 
 [aria-describedby] + div {

--- a/assets/_markdown_styles.scss
+++ b/assets/_markdown_styles.scss
@@ -51,7 +51,7 @@
   }
 }
 
-.in--sidenotes,
+.sidenote.in--sidenotes,
 .footnotes {
   @extend .dn-ns;
 }

--- a/assets/_markdown_styles.scss
+++ b/assets/_markdown_styles.scss
@@ -19,17 +19,8 @@
 }
 
 .in-sidebar {
-  @extend .dn;
-  @extend .db-ns;
-  @extend .absolute-ns;
-  left: 70%;
-  @extend .w-30-ns;
   @extend .f6;
   @extend .mid-gray;
-
-  &.in-sidebar--from-content {
-    @extend .db;
-  }
 
   > ul,
   > ol,

--- a/assets/_markdown_styles.scss
+++ b/assets/_markdown_styles.scss
@@ -18,6 +18,44 @@
   padding-left: 0;
 }
 
+.sidenotes-wrapper {
+  @extend .flex;
+
+  > div {
+    @extend .w-two-thirds-ns;
+  }
+
+  .sidenotes {
+    @extend .dn;
+    @extend .db-ns;
+    @extend .w-third-ns;
+
+    @extend .f6;
+    @extend .mid-gray;
+
+    .sidenote > ul,
+    .sidenote > ol {
+      @extend .list-outside;
+      @extend .pl3;
+    }
+
+    a {
+      @extend .link-arrow;
+      @extend .pv1;
+      @extend .toggle-u-nou;
+    }
+
+    .footnote-return {
+      display: none;
+    }
+  }
+}
+
+.in--sidenotes,
+.footnotes {
+  @extend .dn-ns;
+}
+
 .in-sidebar {
   @extend .f6;
   @extend .mid-gray;

--- a/assets/_markdown_styles.scss
+++ b/assets/_markdown_styles.scss
@@ -26,13 +26,15 @@
   @extend .flex;
 
   > div {
-    @extend .w-two-thirds-ns;
+    @extend .flex-auto;
+    @extend .justify-between;
   }
 
   .sidenotes {
     @extend .dn;
     @extend .db-ns;
     @extend .w-third-ns;
+    @extend .ml4-ns;
     @extend .pt3;
 
     @extend .f6;

--- a/assets/_markdown_styles.scss
+++ b/assets/_markdown_styles.scss
@@ -64,7 +64,6 @@
 
     a {
       @extend .link-arrow;
-      @extend .pv1;
       @extend .toggle-u-nou;
     }
 

--- a/assets/_variables.scss
+++ b/assets/_variables.scss
@@ -1,5 +1,6 @@
 $main-color: #4A4A4A;
 $secondary-color: #E6142D;
+$dark-red: $secondary-color;
 
 $dark-gray: $main-color;
 $mid-gray: #6F6E6E;

--- a/assets/main.js
+++ b/assets/main.js
@@ -58,7 +58,7 @@ var toggleHeadlines = function toggleHeadlines(headlines, untilFn) {
 };
 
 var createSidenotesWrapper = function createSidenotesWrapper(target, delimiters) {
-  if (!target || (target.classList && target.classList.contains('no-sidebar'))) {
+  if (!target || target.classList && target.classList.contains('no-sidebar')) {
     return null;
   }
 
@@ -72,7 +72,7 @@ var createSidenotesWrapper = function createSidenotesWrapper(target, delimiters)
     wrapper.classList.add('sidenotes-wrapper');
 
     var content = document.createElement('div');
-    group.forEach(function(el) {
+    group.forEach(function (el) {
       content.appendChild(el.cloneNode(true));
     });
 
@@ -88,10 +88,12 @@ var createSidenotesWrapper = function createSidenotesWrapper(target, delimiters)
     }
   };
 
-  children.forEach(function(child, i){
+  children.forEach(function (child, i) {
     // is a delimiter
     // we wrap, append, append delimiter and clear the group
-    if (delimiters.find(el => el === child)) {
+    if (delimiters.find(function (el) {
+      return el === child;
+    })) {
       wrapBefore(child);
 
       group = [];
@@ -99,12 +101,12 @@ var createSidenotesWrapper = function createSidenotesWrapper(target, delimiters)
 
     // otherwise, we stack the element in the current group
     else {
-      group.push(child);
+        group.push(child);
 
-      if (i+1 === childrenCount) {
-        wrapBefore();
+        if (i + 1 === childrenCount) {
+          wrapBefore();
+        }
       }
-    }
   });
 
   var clonedTarget = target.cloneNode(false);
@@ -113,11 +115,11 @@ var createSidenotesWrapper = function createSidenotesWrapper(target, delimiters)
   target.parentNode.replaceChild(clonedTarget, target);
 };
 
-var balanceNotes = function balanceNotes (sections, getElements) {
-  sections.forEach(function(section){
+var balanceNotes = function balanceNotes(sections, getElements) {
+  sections.forEach(function (section) {
     var aside = section.querySelector('.sidenotes');
 
-    getElements(section).forEach(function(note){
+    getElements(section).forEach(function (note) {
       var firstChild = note.firstChild;
 
       // footnote
@@ -135,9 +137,9 @@ var balanceNotes = function balanceNotes (sections, getElements) {
       }
       // sidenote
       else {
-        aside.appendChild(note.cloneNode(true));
-        note.classList.add('in--sidenotes');
-      }
+          aside.appendChild(note.cloneNode(true));
+          note.classList.add('in--sidenotes');
+        }
     });
   });
 };
@@ -151,7 +153,7 @@ var balanceNotes = function balanceNotes (sections, getElements) {
     return fromArray(root.querySelectorAll(selector));
   };
 
-  document.addEventListener('DOMContentLoaded', function() {
+  document.addEventListener('DOMContentLoaded', function () {
     var toc = document.getElementById('TableOfContents');
     new MenuSpy(toc, { enableLocationHash: false });
 
@@ -181,16 +183,12 @@ var balanceNotes = function balanceNotes (sections, getElements) {
     // footnotes, sidenotes -> sidebar
     createSidenotesWrapper($('.page__body'), $$('.page__body h1'));
 
-    $$('.article__body').forEach(function(article){
+    $$('.article__body').forEach(function (article) {
       console.log(article);
       createSidenotesWrapper(article, []);
     });
-    // toggleHeadlines($$('.page__body .f2'), function (el) {
-    //   return el.classList.contains('f2');
-    // });
 
-
-    balanceNotes($$('.sidenotes-wrapper'), function(section) {
+    balanceNotes($$('.sidenotes-wrapper'), function (section) {
       return $$('.sidenote, .footnote-ref', section);
     });
 

--- a/assets/main.js
+++ b/assets/main.js
@@ -125,8 +125,9 @@ var balanceNotes = function balanceNotes (sections, getElements) {
         var id = firstChild.hash.slice(1);
         var target = document.getElementById(id);
         var refnote = document.createElement('div');
-        refnote.dataset.refnote = id.split(':')[1];
-        refnote.dataset.note = '#fnref:' + refnote.dataset.refnote;
+        refnote.classList.add('sidenote');
+        refnote.dataset.refnote = firstChild.innerText;
+        refnote.dataset.note = '#fnref:' + id.split(':')[1];
         refnote.innerHTML = target.innerHTML;
 
         aside.appendChild(refnote);

--- a/assets/main.js
+++ b/assets/main.js
@@ -180,6 +180,15 @@ var balanceNotes = function balanceNotes (sections, getElements) {
     // footnotes, sidenotes -> sidebar
     createSidenotesWrapper($('.page__body'), $$('.page__body h1'));
 
+    $$('.article__body').forEach(function(article){
+      console.log(article);
+      createSidenotesWrapper(article, []);
+    });
+    // toggleHeadlines($$('.page__body .f2'), function (el) {
+    //   return el.classList.contains('f2');
+    // });
+
+
     balanceNotes($$('.sidenotes-wrapper'), function(section) {
       return $$('.sidenote, .footnote-ref', section);
     });

--- a/assets/main.js
+++ b/assets/main.js
@@ -58,6 +58,10 @@ var toggleHeadlines = function toggleHeadlines(headlines, untilFn) {
 };
 
 var createSidenotesWrapper = function createSidenotesWrapper(target, delimiters) {
+  if (!target || (target.classList && target.classList.contains('no-sidebar'))) {
+    return null;
+  }
+
   var group = [];
   var children = fromArray(target.children);
   var childrenCount = children.length;

--- a/assets/main.js
+++ b/assets/main.js
@@ -89,10 +89,11 @@ var toggleHeadlines = function toggleHeadlines(headlines, untilFn) {
       });
     }
 
-    // footnotes -> sidenotes
-    $$('.footnotes').forEach(function (footnotes) {
-      footnotes.setAttribute('hidden', true);
+    // footnotes, sidenotes -> sidebar
+    createSidenotesWrapper($$('.page__body h1'));
 
+
+    $$('.footnotes').forEach(function (footnotes) {
       var notes = $$('.footnote-return');
 
       notes.forEach(function (el) {
@@ -104,43 +105,11 @@ var toggleHeadlines = function toggleHeadlines(headlines, untilFn) {
         newNode.style.top = target.offsetTop + 'px';
 
         newNode.innerHTML = el.parentElement.innerHTML;
-        target.insertAdjacentElement('afterend', newNode);
+        // target.insertAdjacentElement('afterend', newNode);
       });
     });
-  });
 
-  // because we'd like to wait for images to load before calculating stuff
-  window.addEventListener('load', function () {
-    // content-notes -> sidenotes
-    $$('.in-sidebar--from-content').forEach(function (sidenote) {
-      var previousElementSibling = sidenote.previousElementSibling;
-
-      if (!previousElementSibling) {
-        return;
-      }
-
-      sidenote.style.top = previousElementSibling.offsetTop + 'px';
-    });
-
-    // realign
-    $$('.in-sidebar').forEach(function (sidenote, i, all) {
-      var previousAlike = all[i - 1];
-
-      if (i === 0 || !sidenote.parentElement.contains(previousAlike)) {
-        return;
-      }
-
-      // move after if overlap
-      var yStart = sidenote.offsetTop;
-      var prevEnd = previousAlike.offsetTop + previousAlike.offsetHeight;
-
-      if (yStart <= prevEnd) {
-        sidenote.style.transform = 'translateY(' + (prevEnd - yStart) + 'px)';
-        sidenote.classList.add('moved');
-      }
-    });
-
-    // toggle state
+    // togglable headlines
     if (document.body.classList.contains('toggable-headlines')) {
       toggleHeadlines($$('.article__title'), function (el) {
         return el.classList.contains('article__title');

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -31,9 +31,7 @@
 
   <main role="main">{{ block "content" . }}{{ end }}</main>
 
-  <aside class="sidenotes" role="aside">
-    {{ block "sidenotes" . }}{{ end }}
-  </aside>
+  <aside role="aside"></aside>
 </section>
 {{ end }}
 

--- a/layouts/_default/outils.html
+++ b/layouts/_default/outils.html
@@ -4,7 +4,7 @@
     <h1>{{ .Page.Title }}</h1>
   </header>
 
-  <div class="page__body">
+  <div class="page__body no-sidebar">
     {{ .Page.Content }}
 
   {{- $Page := .Page -}}

--- a/layouts/shortcodes/sidebar.html
+++ b/layouts/shortcodes/sidebar.html
@@ -1,3 +1,3 @@
-<div class="in-sidebar in-sidebar--from-content {{ .Get "class" }}">
+<div class="sidenote {{ .Get "class" }}">
 {{ .Inner | markdownify }}
 </div>

--- a/resources/_gen/assets/scss/main.scss_f300667da4f5b5f84e1a9e0702b2fdde.content
+++ b/resources/_gen/assets/scss/main.scss_f300667da4f5b5f84e1a9e0702b2fdde.content
@@ -2085,7 +2085,7 @@ header[role="banner"] .secondary-navigation li {
 
 /* 1. Fix for Chrome 44 bug.
  * https://code.google.com/p/chromium/issues/detail?id=506893 */
-.flex-auto {
+.flex-auto, .sidenotes-wrapper > div {
   flex: 1 1 auto;
   min-width: 0;
   /* 1 */
@@ -2157,7 +2157,7 @@ header[role="banner"] .secondary-navigation li {
 .justify-center, .slides .slide {
   justify-content: center; }
 
-.justify-between, .site-footer .main-navigation > ul {
+.justify-between, .site-footer .main-navigation > ul, .sidenotes-wrapper > div {
   justify-content: space-between; }
 
 .justify-around {
@@ -3438,7 +3438,7 @@ body > section [role="main"] {
     width: 100%; }
   .w-third-ns, .sidenotes-wrapper .sidenotes {
     width: 33.33333333%; }
-  .w-two-thirds-ns, .sidenotes-wrapper > div {
+  .w-two-thirds-ns {
     width: 66.66666667%; }
   .w-auto-ns, .site-footer .navigation-item {
     width: auto; } }
@@ -5236,7 +5236,7 @@ body > section [role="main"] {
     margin-left: 0.5rem; }
   .ml3-ns {
     margin-left: 1rem; }
-  .ml4-ns {
+  .ml4-ns, .sidenotes-wrapper .sidenotes {
     margin-left: 2rem; }
   .ml5-ns {
     margin-left: 4rem; }

--- a/resources/_gen/assets/scss/main.scss_f300667da4f5b5f84e1a9e0702b2fdde.content
+++ b/resources/_gen/assets/scss/main.scss_f300667da4f5b5f84e1a9e0702b2fdde.content
@@ -1938,7 +1938,7 @@ img {
      -l  = large
 
 */
-.dn, .slides__nav, body > section > aside {
+.dn, .slides__nav, .sidenotes-wrapper .sidenotes, body > section > aside {
   display: none; }
 
 .di, .bibliography-entry h3, header[role="banner"] .main-navigation li,
@@ -1946,7 +1946,7 @@ header[role="banner"] .language-picker li,
 header[role="banner"] .secondary-navigation li {
   display: inline; }
 
-.db, .link-arrow, .cards-list .card .card__footer a, .bibliography-entry .bibliography-entry__metadata a, .in-sidebar a, .slides__nav a, .site-footer .navigation-item__headline, .cta-list a {
+.db, .link-arrow, .cards-list .card .card__footer a, .bibliography-entry .bibliography-entry__metadata a, .sidenotes-wrapper .sidenotes a, .in-sidebar a, .slides__nav a, .site-footer .navigation-item__headline, .cta-list a {
   display: block; }
 
 .dib {
@@ -1982,11 +1982,12 @@ header[role="banner"] .secondary-navigation li {
   width: 100%; }
 
 @media screen and (min-width: 49em) {
-  .dn-ns {
+  .dn-ns, .in--sidenotes,
+  .footnotes {
     display: none; }
   .di-ns {
     display: inline; }
-  .db-ns, .slides__nav {
+  .db-ns, .slides__nav, .sidenotes-wrapper .sidenotes {
     display: block; }
   .dib-ns {
     display: inline-block; }
@@ -2073,7 +2074,7 @@ header[role="banner"] .secondary-navigation li {
 
 */
 .flex, .slides, .slides .slide, .cards-list .card, .badges-list > ol,
-.badges-list > ul, header[role="banner"], header[role="banner"] .main-navigation, header[role="banner"] .language-picker, .site-footer .main-navigation > ul, .columns, body > section {
+.badges-list > ul, header[role="banner"], header[role="banner"] .main-navigation, header[role="banner"] .language-picker, .site-footer .main-navigation > ul, .columns, .sidenotes-wrapper, body > section {
   display: flex; }
 
 .inline-flex {
@@ -3432,9 +3433,9 @@ body > section [role="main"] {
     width: 90%; }
   .w-100-ns {
     width: 100%; }
-  .w-third-ns {
+  .w-third-ns, .sidenotes-wrapper .sidenotes {
     width: 33.33333333%; }
-  .w-two-thirds-ns {
+  .w-two-thirds-ns, .sidenotes-wrapper > div {
     width: 66.66666667%; }
   .w-auto-ns, .site-footer .navigation-item {
     width: auto; } }
@@ -3670,13 +3671,13 @@ body > section [role="main"] {
 .static {
   position: static; }
 
-.relative, .link-arrow, .cards-list .card .card__footer a, .bibliography-entry .bibliography-entry__metadata a, .in-sidebar a, .slides, .article .article__body,
+.relative, .link-arrow, .cards-list .card .card__footer a, .bibliography-entry .bibliography-entry__metadata a, .sidenotes-wrapper .sidenotes a, .in-sidebar a, .slides, .article .article__body,
 .article .page__body,
 .page .article__body,
 .page .page__body, .clickable, .bibliography > h2, .site-footer .navigation-item, .cta-list a {
   position: relative; }
 
-.absolute, .link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .in-sidebar a:after, .open-close, .site-footer .navigation-item.navigation-item--section:before, #TableOfContents .active:before, [aria-describedby] + div {
+.absolute, .link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after, .in-sidebar a:after, .open-close, .site-footer .navigation-item.navigation-item--section:before, #TableOfContents .active:before, [aria-describedby] + div {
   position: absolute; }
 
 .fixed {
@@ -3917,7 +3918,7 @@ body > section [role="main"] {
 .page .page__body .article__title,
 .page .page__body .article__body h1, .page .article__body .page__body h1,
 .page .article__title h2, .bibliography > h2,
-.bibliography > .bibliography-section > h3, header[role="banner"] a, .site-footer, .site-footer .navigation-item a, #TableOfContents a, .cta-list a:hover, .cta-list a:focus, .in-sidebar {
+.bibliography > .bibliography-section > h3, header[role="banner"] a, .site-footer, .site-footer .navigation-item a, #TableOfContents a, .cta-list a:hover, .cta-list a:focus, .sidenotes-wrapper .sidenotes, .in-sidebar {
   color: #6F6E6E; }
 
 .gray {
@@ -4719,7 +4720,8 @@ header[role="banner"] .secondary-navigation > ul, .site-footer .main-navigation 
 .pl2 {
   padding-left: 0.5rem; }
 
-.pl3, .in-sidebar > ul,
+.pl3, .sidenotes-wrapper .sidenotes .sidenote > ul,
+.sidenotes-wrapper .sidenotes .sidenote > ol, .in-sidebar > ul,
 .in-sidebar > ol,
 .article__body .in-sidebar > ul,
 .article__body .in-sidebar > ol {
@@ -4825,7 +4827,7 @@ header[role="banner"] .secondary-navigation > ul, .site-footer .main-navigation 
   padding-top: 0;
   padding-bottom: 0; }
 
-.pv1, .bibliography-entry .bibliography-entry__metadata a, .in-sidebar a {
+.pv1, .bibliography-entry .bibliography-entry__metadata a, .sidenotes-wrapper .sidenotes a, .in-sidebar a {
   padding-top: 0.25rem;
   padding-bottom: 0.25rem; }
 
@@ -6247,10 +6249,10 @@ body > section [role="main"] {
 .strike {
   text-decoration: line-through; }
 
-.underline, .toggle-u-nou:hover, .cards-list .card .card__footer a:hover, .bibliography-entry .bibliography-entry__metadata a:hover, header[role="banner"] a:hover, .site-footer .navigation-item a:hover, #TableOfContents a:hover, .in-sidebar a:hover, .toggle-u-nou:focus, .cards-list .card .card__footer a:focus, .bibliography-entry .bibliography-entry__metadata a:focus, header[role="banner"] a:focus, .site-footer .navigation-item a:focus, #TableOfContents a:focus, .in-sidebar a:focus, .slides .slide:not(.slide--auto-height) a {
+.underline, .toggle-u-nou:hover, .cards-list .card .card__footer a:hover, .bibliography-entry .bibliography-entry__metadata a:hover, header[role="banner"] a:hover, .site-footer .navigation-item a:hover, #TableOfContents a:hover, .sidenotes-wrapper .sidenotes a:hover, .in-sidebar a:hover, .toggle-u-nou:focus, .cards-list .card .card__footer a:focus, .bibliography-entry .bibliography-entry__metadata a:focus, header[role="banner"] a:focus, .site-footer .navigation-item a:focus, #TableOfContents a:focus, .sidenotes-wrapper .sidenotes a:focus, .in-sidebar a:focus, .slides .slide:not(.slide--auto-height) a {
   text-decoration: underline; }
 
-.no-underline, .toggle-u-nou, .cards-list .card .card__footer a, .bibliography-entry .bibliography-entry__metadata a, header[role="banner"] a, .site-footer .navigation-item a, #TableOfContents a, .in-sidebar a, .slides .slide:not(.slide--auto-height) a:hover, .slides .slide:not(.slide--auto-height) a:focus, .cta-list a {
+.no-underline, .toggle-u-nou, .cards-list .card .card__footer a, .bibliography-entry .bibliography-entry__metadata a, header[role="banner"] a, .site-footer .navigation-item a, #TableOfContents a, .sidenotes-wrapper .sidenotes a, .in-sidebar a, .slides .slide:not(.slide--auto-height) a:hover, .slides .slide:not(.slide--auto-height) a:focus, .cta-list a {
   text-decoration: none; }
 
 @media screen and (min-width: 49em) {
@@ -6463,7 +6465,7 @@ body > section [role="main"] {
 .page .article__body h2, .bibliography-entry h3, header[role="banner"] {
   font-size: 1rem; }
 
-.f6, .cards-list .card .card__footer, .bibliography-entry .bibliography-entry__metadata, .in-sidebar {
+.f6, .cards-list .card .card__footer, .bibliography-entry .bibliography-entry__metadata, .sidenotes-wrapper .sidenotes, .in-sidebar {
   font-size: .875rem; }
 
 .f7, .site-footer {
@@ -7116,7 +7118,7 @@ body > section [role="main"] {
 .no-break-word, .site-footer .navigation-item a {
   overflow-wrap: unset; }
 
-.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .in-sidebar a:after {
+.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after, .in-sidebar a:after {
   content: "→";
   right: 0; }
 
@@ -7148,7 +7150,7 @@ body > section [role="main"] {
 .no-break-word, .site-footer .navigation-item a {
   overflow-wrap: unset; }
 
-.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .in-sidebar a:after {
+.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after, .in-sidebar a:after {
   content: "→";
   right: 0; }
 
@@ -7174,7 +7176,7 @@ body > section [role="main"] {
 .no-break-word, .site-footer .navigation-item a {
   overflow-wrap: unset; }
 
-.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .in-sidebar a:after {
+.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after, .in-sidebar a:after {
   content: "→";
   right: 0; }
 
@@ -7193,7 +7195,7 @@ body > section [role="main"] {
 .no-break-word, .site-footer .navigation-item a {
   overflow-wrap: unset; }
 
-.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .in-sidebar a:after {
+.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after, .in-sidebar a:after {
   content: "→";
   right: 0; }
 
@@ -7209,7 +7211,8 @@ body > section [role="main"] {
 .page .page__body ul {
   list-style-position: inside; }
 
-.list-outside, .in-sidebar > ul,
+.list-outside, .sidenotes-wrapper .sidenotes .sidenote > ul,
+.sidenotes-wrapper .sidenotes .sidenote > ol, .in-sidebar > ul,
 .in-sidebar > ol,
 .article__body .in-sidebar > ul,
 .article__body .in-sidebar > ol {
@@ -7286,7 +7289,7 @@ body > section [role="main"] {
 .no-break-word, .site-footer .navigation-item a {
   overflow-wrap: unset; }
 
-.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .in-sidebar a:after {
+.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after, .in-sidebar a:after {
   content: "→";
   right: 0; }
 
@@ -7296,7 +7299,7 @@ body > section [role="main"] {
 .no-break-word, .site-footer .navigation-item a {
   overflow-wrap: unset; }
 
-.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .in-sidebar a:after {
+.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after, .in-sidebar a:after {
   content: "→";
   right: 0; }
 
@@ -7306,7 +7309,7 @@ body > section [role="main"] {
 .no-break-word, .site-footer .navigation-item a {
   overflow-wrap: unset; }
 
-.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .in-sidebar a:after {
+.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after, .in-sidebar a:after {
   content: "→";
   right: 0; }
 
@@ -7322,7 +7325,8 @@ body > section [role="main"] {
 .page .page__body ul {
   list-style-position: inside; }
 
-.list-outside, .in-sidebar > ul,
+.list-outside, .sidenotes-wrapper .sidenotes .sidenote > ul,
+.sidenotes-wrapper .sidenotes .sidenote > ol, .in-sidebar > ul,
 .in-sidebar > ol,
 .article__body .in-sidebar > ul,
 .article__body .in-sidebar > ol {
@@ -7350,7 +7354,7 @@ header[role="banner"] {
 .no-break-word, .site-footer .navigation-item a {
   overflow-wrap: unset; }
 
-.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .in-sidebar a:after {
+.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after, .in-sidebar a:after {
   content: "→";
   right: 0; }
 
@@ -7377,7 +7381,7 @@ header[role="banner"] {
 .no-break-word, .site-footer .navigation-item a {
   overflow-wrap: unset; }
 
-.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .in-sidebar a:after {
+.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after, .in-sidebar a:after {
   content: "→";
   right: 0; }
 
@@ -7394,7 +7398,7 @@ header[role="banner"] {
 .no-break-word, .site-footer .navigation-item a {
   overflow-wrap: unset; }
 
-.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .in-sidebar a:after {
+.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after, .in-sidebar a:after {
   content: "→";
   right: 0; }
 
@@ -7407,7 +7411,7 @@ header[role="banner"] {
 .no-break-word, .site-footer .navigation-item a {
   overflow-wrap: unset; }
 
-.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .in-sidebar a:after {
+.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after, .in-sidebar a:after {
   content: "→";
   right: 0; }
 
@@ -7423,7 +7427,8 @@ header[role="banner"] {
 .page .page__body ul {
   list-style-position: inside; }
 
-.list-outside, .in-sidebar > ul,
+.list-outside, .sidenotes-wrapper .sidenotes .sidenote > ul,
+.sidenotes-wrapper .sidenotes .sidenote > ol, .in-sidebar > ul,
 .in-sidebar > ol,
 .article__body .in-sidebar > ul,
 .article__body .in-sidebar > ol {
@@ -7435,7 +7440,7 @@ header[role="banner"] {
 .no-break-word, .site-footer .navigation-item a {
   overflow-wrap: unset; }
 
-.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .in-sidebar a:after {
+.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after, .in-sidebar a:after {
   content: "→";
   right: 0; }
 
@@ -7449,6 +7454,9 @@ header[role="banner"] {
 .footnotes ol {
   margin-top: 1.5em;
   padding-left: 0; }
+
+.sidenotes-wrapper .sidenotes .footnote-return {
+  display: none; }
 
 .in-sidebar .footnote-return {
   display: none; }

--- a/resources/_gen/assets/scss/main.scss_f300667da4f5b5f84e1a9e0702b2fdde.content
+++ b/resources/_gen/assets/scss/main.scss_f300667da4f5b5f84e1a9e0702b2fdde.content
@@ -1982,7 +1982,7 @@ header[role="banner"] .secondary-navigation li {
   width: 100%; }
 
 @media screen and (min-width: 49em) {
-  .dn-ns, .in--sidenotes,
+  .dn-ns, .sidenote.in--sidenotes,
   .footnotes {
     display: none; }
   .di-ns {

--- a/resources/_gen/assets/scss/main.scss_f300667da4f5b5f84e1a9e0702b2fdde.content
+++ b/resources/_gen/assets/scss/main.scss_f300667da4f5b5f84e1a9e0702b2fdde.content
@@ -161,7 +161,8 @@ small {
  * all browsers.
  */
 sub,
-sup {
+sup,
+.sidenotes-wrapper .sidenotes .sidenote[data-refnote]:before {
   font-size: 75%;
   line-height: 0;
   position: relative;
@@ -170,7 +171,9 @@ sup {
 sub {
   bottom: -0.25em; }
 
-sup {
+
+sup,
+.sidenotes-wrapper .sidenotes .sidenote[data-refnote]:before {
   top: -0.5em; }
 
 /* Embedded content
@@ -1125,7 +1128,7 @@ img {
   border-color: rgba(0, 0, 0, 0.0125); }
 
 .b--dark-red {
-  border-color: #e7040f; }
+  border-color: #E6142D; }
 
 .b--red {
   border-color: #ff4136; }
@@ -1645,7 +1648,7 @@ img {
      -l  = large
 
 */
-.top-0 {
+.top-0, .sidenotes-wrapper .sidenotes .sidenote[data-refnote]:before {
   top: 0; }
 
 .right-0, .open-close {
@@ -1690,7 +1693,7 @@ img {
 .bottom--1 {
   bottom: -1rem; }
 
-.left--1 {
+.left--1, .sidenotes-wrapper .sidenotes .sidenote[data-refnote]:before {
   left: -1rem; }
 
 .top--2 {
@@ -1946,7 +1949,7 @@ header[role="banner"] .language-picker li,
 header[role="banner"] .secondary-navigation li {
   display: inline; }
 
-.db, .link-arrow, .cards-list .card .card__footer a, .bibliography-entry .bibliography-entry__metadata a, .sidenotes-wrapper .sidenotes a, .in-sidebar a, .slides__nav a, .site-footer .navigation-item__headline, .cta-list a {
+.db, .link-arrow, .cards-list .card .card__footer a, .bibliography-entry .bibliography-entry__metadata a, .sidenotes-wrapper .sidenotes a, .slides__nav a, .site-footer .navigation-item__headline, .cta-list a {
   display: block; }
 
 .dib {
@@ -3049,7 +3052,7 @@ header[role="banner"] .secondary-navigation .active, #TableOfContents .active {
 .page .page__body h1, .article .article__body h2,
 .article .page__body h2,
 .page .article__body h2,
-.page .page__body h2 {
+.page .page__body h2, .sidenotes-wrapper .sidenotes .sidenote, .sidenotes-wrapper .sidenotes .sidenote[data-refnote]:before {
   line-height: 1.25; }
 
 .lh-copy, main h5, main h6, [role="main"] h5, [role="main"] h6, main p, main li, [role="main"] p, [role="main"] li, .article .article__body p, .article .article__body li, .article .article__body video, .article .article__body iframe,
@@ -3671,13 +3674,13 @@ body > section [role="main"] {
 .static {
   position: static; }
 
-.relative, .link-arrow, .cards-list .card .card__footer a, .bibliography-entry .bibliography-entry__metadata a, .sidenotes-wrapper .sidenotes a, .in-sidebar a, .slides, .article .article__body,
+.relative, .link-arrow, .cards-list .card .card__footer a, .bibliography-entry .bibliography-entry__metadata a, .sidenotes-wrapper .sidenotes a, .slides, .article .article__body,
 .article .page__body,
 .page .article__body,
-.page .page__body, .clickable, .bibliography > h2, .site-footer .navigation-item, .cta-list a {
+.page .page__body, .clickable, .bibliography > h2, .site-footer .navigation-item, .cta-list a, .sidenotes-wrapper .sidenotes .sidenote {
   position: relative; }
 
-.absolute, .link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after, .in-sidebar a:after, .open-close, .site-footer .navigation-item.navigation-item--section:before, #TableOfContents .active:before, [aria-describedby] + div {
+.absolute, .link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after, .open-close, .site-footer .navigation-item.navigation-item--section:before, #TableOfContents .active:before, .sidenotes-wrapper .sidenotes .sidenote[data-refnote]:before, [aria-describedby] + div {
   position: absolute; }
 
 .fixed {
@@ -3918,7 +3921,7 @@ body > section [role="main"] {
 .page .page__body .article__title,
 .page .page__body .article__body h1, .page .article__body .page__body h1,
 .page .article__title h2, .bibliography > h2,
-.bibliography > .bibliography-section > h3, header[role="banner"] a, .site-footer, .site-footer .navigation-item a, #TableOfContents a, .cta-list a:hover, .cta-list a:focus, .sidenotes-wrapper .sidenotes, .in-sidebar {
+.bibliography > .bibliography-section > h3, header[role="banner"] a, .site-footer, .site-footer .navigation-item a, #TableOfContents a, .cta-list a:hover, .cta-list a:focus, .sidenotes-wrapper .sidenotes {
   color: #6F6E6E; }
 
 .gray {
@@ -3942,8 +3945,8 @@ body > section [role="main"] {
 .white, header[role="banner"] .secondary-navigation a:hover, header[role="banner"] .secondary-navigation a:focus {
   color: #fff; }
 
-.dark-red {
-  color: #e7040f; }
+.dark-red, .sidenotes-wrapper .sidenotes .sidenote[data-refnote]:before {
+  color: #E6142D; }
 
 .red {
   color: #ff4136; }
@@ -4115,7 +4118,7 @@ body > section [role="main"] {
   background-color: transparent; }
 
 .bg-dark-red {
-  background-color: #e7040f; }
+  background-color: #E6142D; }
 
 .bg-red {
   background-color: #ff4136; }
@@ -4442,7 +4445,7 @@ body > section [role="main"] {
 
 .hover-dark-red:hover,
 .hover-dark-red:focus {
-  color: #e7040f; }
+  color: #E6142D; }
 
 .hover-red:hover,
 .hover-red:focus {
@@ -4542,7 +4545,7 @@ body > section [role="main"] {
 
 .hover-bg-dark-red:hover,
 .hover-bg-dark-red:focus {
-  background-color: #e7040f; }
+  background-color: #E6142D; }
 
 .hover-bg-red:hover,
 .hover-bg-red:focus {
@@ -4721,10 +4724,7 @@ header[role="banner"] .secondary-navigation > ul, .site-footer .main-navigation 
   padding-left: 0.5rem; }
 
 .pl3, .sidenotes-wrapper .sidenotes .sidenote > ul,
-.sidenotes-wrapper .sidenotes .sidenote > ol, .in-sidebar > ul,
-.in-sidebar > ol,
-.article__body .in-sidebar > ul,
-.article__body .in-sidebar > ol {
+.sidenotes-wrapper .sidenotes .sidenote > ol {
   padding-left: 1rem; }
 
 .pl4 {
@@ -4808,7 +4808,7 @@ header[role="banner"] .secondary-navigation > ul, .site-footer .main-navigation 
 .pt2, h2 + .bibliography-entry {
   padding-top: 0.5rem; }
 
-.pt3, .bibliography-entry {
+.pt3, .bibliography-entry, .sidenotes-wrapper .sidenotes {
   padding-top: 1rem; }
 
 .pt4, .bibliography-entry:not(.bibliography-entry--quiet) {
@@ -4827,7 +4827,7 @@ header[role="banner"] .secondary-navigation > ul, .site-footer .main-navigation 
   padding-top: 0;
   padding-bottom: 0; }
 
-.pv1, .bibliography-entry .bibliography-entry__metadata a, .sidenotes-wrapper .sidenotes a, .in-sidebar a {
+.pv1, .bibliography-entry .bibliography-entry__metadata a, .sidenotes-wrapper .sidenotes a {
   padding-top: 0.25rem;
   padding-bottom: 0.25rem; }
 
@@ -4859,7 +4859,7 @@ header[role="banner"] .secondary-navigation > ul, .site-footer .main-navigation 
   padding-left: 0;
   padding-right: 0; }
 
-.ph1 {
+.ph1, .footnote-ref {
   padding-left: 0.25rem;
   padding-right: 0.25rem; }
 
@@ -4972,7 +4972,7 @@ header[role="banner"] .secondary-navigation li {
   margin-bottom: 0.5rem; }
 
 .mb3, .cards-list .card, .badges-list > ol > li,
-.badges-list > ul > li {
+.badges-list > ul > li, .sidenotes-wrapper .sidenotes .sidenote {
   margin-bottom: 1rem; }
 
 .mb4 {
@@ -6249,10 +6249,10 @@ body > section [role="main"] {
 .strike {
   text-decoration: line-through; }
 
-.underline, .toggle-u-nou:hover, .cards-list .card .card__footer a:hover, .bibliography-entry .bibliography-entry__metadata a:hover, header[role="banner"] a:hover, .site-footer .navigation-item a:hover, #TableOfContents a:hover, .sidenotes-wrapper .sidenotes a:hover, .in-sidebar a:hover, .toggle-u-nou:focus, .cards-list .card .card__footer a:focus, .bibliography-entry .bibliography-entry__metadata a:focus, header[role="banner"] a:focus, .site-footer .navigation-item a:focus, #TableOfContents a:focus, .sidenotes-wrapper .sidenotes a:focus, .in-sidebar a:focus, .slides .slide:not(.slide--auto-height) a {
+.underline, .toggle-u-nou:hover, .cards-list .card .card__footer a:hover, .bibliography-entry .bibliography-entry__metadata a:hover, header[role="banner"] a:hover, .site-footer .navigation-item a:hover, #TableOfContents a:hover, .sidenotes-wrapper .sidenotes a:hover, .toggle-u-nou:focus, .cards-list .card .card__footer a:focus, .bibliography-entry .bibliography-entry__metadata a:focus, header[role="banner"] a:focus, .site-footer .navigation-item a:focus, #TableOfContents a:focus, .sidenotes-wrapper .sidenotes a:focus, .slides .slide:not(.slide--auto-height) a, .sidenotes-wrapper .sidenotes .sidenote[data-refnote]:before {
   text-decoration: underline; }
 
-.no-underline, .toggle-u-nou, .cards-list .card .card__footer a, .bibliography-entry .bibliography-entry__metadata a, header[role="banner"] a, .site-footer .navigation-item a, #TableOfContents a, .sidenotes-wrapper .sidenotes a, .in-sidebar a, .slides .slide:not(.slide--auto-height) a:hover, .slides .slide:not(.slide--auto-height) a:focus, .cta-list a {
+.no-underline, .toggle-u-nou, .cards-list .card .card__footer a, .bibliography-entry .bibliography-entry__metadata a, header[role="banner"] a, .site-footer .navigation-item a, #TableOfContents a, .sidenotes-wrapper .sidenotes a, .slides .slide:not(.slide--auto-height) a:hover, .slides .slide:not(.slide--auto-height) a:focus, .cta-list a {
   text-decoration: none; }
 
 @media screen and (min-width: 49em) {
@@ -6465,7 +6465,7 @@ body > section [role="main"] {
 .page .article__body h2, .bibliography-entry h3, header[role="banner"] {
   font-size: 1rem; }
 
-.f6, .cards-list .card .card__footer, .bibliography-entry .bibliography-entry__metadata, .sidenotes-wrapper .sidenotes, .in-sidebar {
+.f6, .cards-list .card .card__footer, .bibliography-entry .bibliography-entry__metadata, .sidenotes-wrapper .sidenotes {
   font-size: .875rem; }
 
 .f7, .site-footer {
@@ -7118,7 +7118,7 @@ body > section [role="main"] {
 .no-break-word, .site-footer .navigation-item a {
   overflow-wrap: unset; }
 
-.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after, .in-sidebar a:after {
+.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after {
   content: "→";
   right: 0; }
 
@@ -7150,7 +7150,7 @@ body > section [role="main"] {
 .no-break-word, .site-footer .navigation-item a {
   overflow-wrap: unset; }
 
-.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after, .in-sidebar a:after {
+.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after {
   content: "→";
   right: 0; }
 
@@ -7176,7 +7176,7 @@ body > section [role="main"] {
 .no-break-word, .site-footer .navigation-item a {
   overflow-wrap: unset; }
 
-.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after, .in-sidebar a:after {
+.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after {
   content: "→";
   right: 0; }
 
@@ -7195,7 +7195,7 @@ body > section [role="main"] {
 .no-break-word, .site-footer .navigation-item a {
   overflow-wrap: unset; }
 
-.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after, .in-sidebar a:after {
+.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after {
   content: "→";
   right: 0; }
 
@@ -7212,10 +7212,7 @@ body > section [role="main"] {
   list-style-position: inside; }
 
 .list-outside, .sidenotes-wrapper .sidenotes .sidenote > ul,
-.sidenotes-wrapper .sidenotes .sidenote > ol, .in-sidebar > ul,
-.in-sidebar > ol,
-.article__body .in-sidebar > ul,
-.article__body .in-sidebar > ol {
+.sidenotes-wrapper .sidenotes .sidenote > ol {
   list-style-position: outside; }
 
 .article .article__body p:empty:last-child,
@@ -7289,7 +7286,7 @@ body > section [role="main"] {
 .no-break-word, .site-footer .navigation-item a {
   overflow-wrap: unset; }
 
-.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after, .in-sidebar a:after {
+.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after {
   content: "→";
   right: 0; }
 
@@ -7299,7 +7296,7 @@ body > section [role="main"] {
 .no-break-word, .site-footer .navigation-item a {
   overflow-wrap: unset; }
 
-.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after, .in-sidebar a:after {
+.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after {
   content: "→";
   right: 0; }
 
@@ -7309,7 +7306,7 @@ body > section [role="main"] {
 .no-break-word, .site-footer .navigation-item a {
   overflow-wrap: unset; }
 
-.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after, .in-sidebar a:after {
+.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after {
   content: "→";
   right: 0; }
 
@@ -7326,10 +7323,7 @@ body > section [role="main"] {
   list-style-position: inside; }
 
 .list-outside, .sidenotes-wrapper .sidenotes .sidenote > ul,
-.sidenotes-wrapper .sidenotes .sidenote > ol, .in-sidebar > ul,
-.in-sidebar > ol,
-.article__body .in-sidebar > ul,
-.article__body .in-sidebar > ol {
+.sidenotes-wrapper .sidenotes .sidenote > ol {
   list-style-position: outside; }
 
 header[role="banner"] {
@@ -7354,7 +7348,7 @@ header[role="banner"] {
 .no-break-word, .site-footer .navigation-item a {
   overflow-wrap: unset; }
 
-.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after, .in-sidebar a:after {
+.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after {
   content: "→";
   right: 0; }
 
@@ -7381,7 +7375,7 @@ header[role="banner"] {
 .no-break-word, .site-footer .navigation-item a {
   overflow-wrap: unset; }
 
-.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after, .in-sidebar a:after {
+.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after {
   content: "→";
   right: 0; }
 
@@ -7398,7 +7392,7 @@ header[role="banner"] {
 .no-break-word, .site-footer .navigation-item a {
   overflow-wrap: unset; }
 
-.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after, .in-sidebar a:after {
+.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after {
   content: "→";
   right: 0; }
 
@@ -7411,7 +7405,7 @@ header[role="banner"] {
 .no-break-word, .site-footer .navigation-item a {
   overflow-wrap: unset; }
 
-.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after, .in-sidebar a:after {
+.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after {
   content: "→";
   right: 0; }
 
@@ -7428,10 +7422,7 @@ header[role="banner"] {
   list-style-position: inside; }
 
 .list-outside, .sidenotes-wrapper .sidenotes .sidenote > ul,
-.sidenotes-wrapper .sidenotes .sidenote > ol, .in-sidebar > ul,
-.in-sidebar > ol,
-.article__body .in-sidebar > ul,
-.article__body .in-sidebar > ol {
+.sidenotes-wrapper .sidenotes .sidenote > ol {
   list-style-position: outside; }
 
 .break-word, a {
@@ -7440,7 +7431,7 @@ header[role="banner"] {
 .no-break-word, .site-footer .navigation-item a {
   overflow-wrap: unset; }
 
-.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after, .in-sidebar a:after {
+.link-arrow:after, .cards-list .card .card__footer a:after, .bibliography-entry .bibliography-entry__metadata a:after, .sidenotes-wrapper .sidenotes a:after {
   content: "→";
   right: 0; }
 
@@ -7455,10 +7446,10 @@ header[role="banner"] {
   margin-top: 1.5em;
   padding-left: 0; }
 
-.sidenotes-wrapper .sidenotes .footnote-return {
-  display: none; }
+.sidenotes-wrapper .sidenotes .sidenote[data-refnote]:before {
+  content: attr(data-refnote); }
 
-.in-sidebar .footnote-return {
+.sidenotes-wrapper .sidenotes .footnote-return {
   display: none; }
 
 [aria-describedby] + div {

--- a/resources/_gen/assets/scss/main.scss_f300667da4f5b5f84e1a9e0702b2fdde.content
+++ b/resources/_gen/assets/scss/main.scss_f300667da4f5b5f84e1a9e0702b2fdde.content
@@ -1938,7 +1938,7 @@ img {
      -l  = large
 
 */
-.dn, .slides__nav, .in-sidebar, body > section > aside {
+.dn, .slides__nav, body > section > aside {
   display: none; }
 
 .di, .bibliography-entry h3, header[role="banner"] .main-navigation li,
@@ -1946,7 +1946,7 @@ header[role="banner"] .language-picker li,
 header[role="banner"] .secondary-navigation li {
   display: inline; }
 
-.db, .link-arrow, .cards-list .card .card__footer a, .bibliography-entry .bibliography-entry__metadata a, .in-sidebar a, .slides__nav a, .site-footer .navigation-item__headline, .cta-list a, .in-sidebar.in-sidebar--from-content {
+.db, .link-arrow, .cards-list .card .card__footer a, .bibliography-entry .bibliography-entry__metadata a, .in-sidebar a, .slides__nav a, .site-footer .navigation-item__headline, .cta-list a {
   display: block; }
 
 .dib {
@@ -1986,7 +1986,7 @@ header[role="banner"] .secondary-navigation li {
     display: none; }
   .di-ns {
     display: inline; }
-  .db-ns, .slides__nav, .in-sidebar {
+  .db-ns, .slides__nav {
     display: block; }
   .dib-ns {
     display: inline-block; }
@@ -3403,7 +3403,7 @@ body > section [role="main"] {
     width: 20%; }
   .w-25-ns, .slides .slide:nth-of-type(2) p {
     width: 25%; }
-  .w-30-ns, .in-sidebar {
+  .w-30-ns {
     width: 30%; }
   .w-33-ns {
     width: 33%; }
@@ -3687,7 +3687,7 @@ body > section [role="main"] {
     position: static; }
   .relative-ns {
     position: relative; }
-  .absolute-ns, .in-sidebar {
+  .absolute-ns {
     position: absolute; }
   .fixed-ns, .slides__nav {
     position: fixed; } }
@@ -7450,10 +7450,8 @@ header[role="banner"] {
   margin-top: 1.5em;
   padding-left: 0; }
 
-.in-sidebar {
-  left: 70%; }
-  .in-sidebar .footnote-return {
-    display: none; }
+.in-sidebar .footnote-return {
+  display: none; }
 
 [aria-describedby] + div {
   left: -500em; }

--- a/resources/_gen/assets/scss/main.scss_f300667da4f5b5f84e1a9e0702b2fdde.content
+++ b/resources/_gen/assets/scss/main.scss_f300667da4f5b5f84e1a9e0702b2fdde.content
@@ -4827,7 +4827,7 @@ header[role="banner"] .secondary-navigation > ul, .site-footer .main-navigation 
   padding-top: 0;
   padding-bottom: 0; }
 
-.pv1, .bibliography-entry .bibliography-entry__metadata a, .sidenotes-wrapper .sidenotes a {
+.pv1, .bibliography-entry .bibliography-entry__metadata a {
   padding-top: 0.25rem;
   padding-bottom: 0.25rem; }
 


### PR DESCRIPTION
Le design prévu est très complexe à réaliser. Peut on trouver une solution technique remettant en cause le design mais pouvant être mise en place rapidement ?

Précision : la carnet ne concerne que le mode non responsive. Par ailleurs cet affichage concerne les deux types de notes.

Proposition : 
- les sections ont deux colonnes, une colonne texte avec des paragraphes et une colonne avec les notes (à droite)
- si il y a une note dans un paragraphe on l'indique dans le texte avec un numéro de renvoi (Pas d'interaction)
- les contenus des notes sont mis dans la colonne note sans alignement verticale, les notes s'empilent dans l'ordre de leur insertion dans la section avec un séparateur graphique (léger margin + liseret rouge). Le numéro de renvoi est en préfixe du contenu de la note.
- si le contenu des notes dépasse verticalement le contenu des paragraphes la hauteur de la section est augmentée pour voir toutes les notes. 

version avec note en bas de page:
https://cdsp-scpo.github.io/site-DIME-SHS/instruments/bequali/

version avec sidenote alignée:
https://cdsp-scpo.github.io/site-DIME-SHS/projet/organisation/