### PR TITLE
Ajoute une ancre sur chaque actualité

### DIFF
--- a/layouts/partials/contents/post.html
+++ b/layouts/partials/contents/post.html
@@ -1,4 +1,4 @@
-<article class="article section--{{ .Section }}">
+<article class="article section--{{ .Section }}" id="post-{{ .File.TranslationBaseName | lower }}">
   <header class="article__title">
     <h2>{{ .Title }}</h2>
   </header>


### PR DESCRIPTION
Si l'actu est dans `content/posts/changement-direction.fr.md`, le permalien est  `post-changement-direction` (`content/posts/changement-direction.fr.md` → `changement-direction` → `post-changement-direction`).

Pour faire un lien vers cette page : `[](/#post-changement-direction)`.

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/138627/48338747-bdca3b00-e666-11e8-97e5-a562107dba99.png">
