### PR TITLE
Gestion des HTMLEntities dans les titres des publications

### DIFF
--- a/data/publications/dime-web.yml
+++ b/data/publications/dime-web.yml
@@ -344,8 +344,8 @@
   publication: null
   category: dime-web
 - id: oai:spire.sciencespo.fr:2441/15bh4udemm8439nhc008loqhn3
-  title: "Outils &amp; méthodes pour créer, traiter et analyser des corpus web:INA
-    DLWeb - Saison 6 atelier 3 : Qu’est ce qu’un corpus web ?"
+  title: "Outils & méthodes pour créer, traiter et analyser des corpus web:INA DLWeb
+    - Saison 6 atelier 3 : Qu’est ce qu’un corpus web ?"
   authors:
     - Ooghe, Benjamin
   date: 2015-04-17

--- a/package-lock.json
+++ b/package-lock.json
@@ -1772,6 +1772,11 @@
         }
       }
     },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+    },
     "hosted-git-info": {
       "version": "2.8.4",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@iarna/toml": "^2.2.3",
     "esm": "^3.2.25",
     "fast-xml-parser": "^3.12.20",
+    "he": "^1.2.0",
     "http-link-header": "^1.0.2",
     "lodash.intersection": "^4.4.0",
     "menuspy": "^1.3.0",

--- a/scripts/import/spire.js
+++ b/scripts/import/spire.js
@@ -1,6 +1,7 @@
-const {get} = require('superagent');
-const {getCategory, getDefaultCategory, cleanUrl} = require('./helpers.js');
-const {parse} = require('fast-xml-parser');
+import {get} from 'superagent';
+import {decode} from 'he';
+import {getCategory, getDefaultCategory, cleanUrl} from './helpers.js';
+import {parse} from 'fast-xml-parser';
 
 const getType = (type) => {
   return type.split('/').pop();
@@ -13,7 +14,7 @@ const getUrl = (urls) => {
     .pop();
 };
 
-const importer = (source, {publicationsMapping:mappingConfig, publications, publicationsLabels}) => {
+export default function importer (source, {publicationsMapping:mappingConfig, publications, publicationsLabels}) {
   const DEFAULT_CATEGORY = getDefaultCategory(publications);
   const {spire:publicationsMapping} = mappingConfig;
 
@@ -39,7 +40,7 @@ const importer = (source, {publicationsMapping:mappingConfig, publications, publ
 
         return {
           id,
-          title,
+          title: decode(title),
           authors: Array.isArray(authors) ? authors : [authors],
           date: Array.isArray(date) ? date.join(', ') : date,
           url: cleanUrl(url),
@@ -53,5 +54,3 @@ const importer = (source, {publicationsMapping:mappingConfig, publications, publ
       return {items, publications};
     })
 };
-
-module.exports = importer;


### PR DESCRIPTION
Certain titres de publications issues de Zotero et Spire contiennent parfois des HTMLEntities qu'il faudrait gérer, j'ai notamment repéré un `&amp;` dans la 4ème publication de Dime Web/Communications orales sur https://deploy-preview-66--kind-mccarthy-fd4dfe.netlify.com/productions/publications/