### PR TITLE
Productions / Publications : l'ordonnancement est antéchronologiq…

### DIFF
--- a/data/publications/bequali.yml
+++ b/data/publications/bequali.yml
@@ -2,7 +2,7 @@
   title: Genre et « Formation du couple », réanalyser une enquête canonique
   authors:
     - Descoutures, Virginie
-  date: 12-13 décembre 2014
+  date: 2014-12-12
   url: ""
   type: Communications orales
   issue: null
@@ -33,7 +33,7 @@
     - Rioufreyt, Thibaut
     - Bachelot, Carole
     - Guaspare, Catherine
-  date: 12-13 décembre 2014
+  date: 2014-12-12
   url: ""
   type: Communications orales
   issue: null
@@ -139,7 +139,7 @@
   authors:
     - Garcia, Guillaume
     - Juillard, Emeline
-  date: 2019-01
+  date: 2019-01-01
   url: http://spire.sciencespo.fr/hdl:/2441/2pn65l78en94t9neo42pgj31no
   type: Rapports
   source: null
@@ -188,7 +188,7 @@
   title: Enquête sur l’enquête « Des femmes en politique » de Mariette Sineau
   authors:
     - Garcia, Guillaume
-  date: 2016-01
+  date: 2016-01-01
   url: http://bequali.fr/fr/les-enquetes/lenquete-en-bref/cdsp_bequali_sp6/
   type: Rapports
   source: null
@@ -215,7 +215,7 @@
   title: Enquête sur l’enquête « Les français et la politique » de Etienne Schweisguth
   authors:
     - Garcia, Guillaume
-  date: 2013-01
+  date: 2013-01-01
   url: http://bequali.fr/fr/les-enquetes/lenquete-sur-lenquete/cdsp_bequali_sp2/
   type: Rapports
   source: null
@@ -228,7 +228,7 @@
     Ingelgom
   authors:
     - Garcia, Guillaume
-  date: 2013-01
+  date: 2013-01-01
   url: http://bequali.fr/fr/les-enquetes/lenquete-sur-lenquete/cdsp_bequali_sp1/
   type: Rapports
   source: null
@@ -372,7 +372,7 @@
   authors:
     - Duchesne, Sophie
     - Garcia, Guillaume
-  date: 2014, 2014
+  date: 2014
   url: http://spire.sciencespo.fr/hdl:/2441/6bepl9034o9merg5eb6rienb1c
   type: Communications orales
   source: Les archives de la recherche, pratique des acteurs et enjeux juridiques; Les
@@ -386,7 +386,7 @@
   authors:
     - Garcia, Guillaume
     - Van Zanten, Agnès
-  date: 2016-01
+  date: 2016-01-01
   url: http://bequali.fr/fr/les-enquetes/lenquete-sur-lenquete/cdsp_bequali_s1/
   type: Rapports
   source: null
@@ -397,7 +397,7 @@
     Olivier Rozenberg
   authors:
     - Garcia, Guillaume
-  date: 2013-01
+  date: 2013-01-01
   url: http://bequali.fr/fr/les-enquetes/lenquete-sur-lenquete/cdsp_bequali_sp3/
   type: Rapports
   source: null
@@ -426,7 +426,7 @@
   authors:
     - Souanef, Karim
     - Cadorel, Sarah
-  date: 2015-01
+  date: 2015-01-01
   url: http://bequali.fr/fr/les-enquetes/lenquete-en-bref/cdsp_bequali_sp5/
   type: Rapports
   source: null

--- a/data/publications/dime-web.yml
+++ b/data/publications/dime-web.yml
@@ -113,7 +113,7 @@
   authors:
     - Romele, Alberto
     - Severo, Marta
-  date: May 2016
+  date: 2016-05
   url: https://hal.archives-ouvertes.fr/hal-01294443
   type: Articles
   issue: "6"
@@ -186,7 +186,7 @@
     - Fretigny, Raphael
     - Colgrove, James
     - Seror, Valérie
-  date: January 1, 2019
+  date: 2019-01-01
   url: http://www.sciencedirect.com/science/article/pii/S0277953618306282
   type: Articles
   issue: ""
@@ -216,7 +216,7 @@
     - Bigot, Jean-Edouard
     - Julliard, Virginie
     - Mabi, Clément
-  date: 2016/01/01
+  date: 2016-01-01
   url: http://journals.openedition.org/rfsic/1783
   type: Articles
   issue: "8"
@@ -297,7 +297,7 @@
     Datasets"
   authors:
     - Munk, Anders Kristian
-  date: 2014/11/01
+  date: 2014-11-01
   url: https://papers.ssrn.com/abstract=2595287
   type: Rapports
   issue: null
@@ -314,7 +314,7 @@
     - Colombo, Gabriele
     - Meunier, Axel
     - Brilli, Agata
-  date: 2017, 2017
+  date: 2017
   url: http://spire.sciencespo.fr/hdl:/2441/10ctml1egq89ro59upjajbj74n
   type: Communications orales
   source: International Conference on Public Policy (ICPP3), Singapore, SG,
@@ -397,7 +397,7 @@
     - Paddeu, Flaminia
     - Douay, Nicolas, Géographie-Cités
     - Blanc, Nathalie
-  date: 2017-11, 1993
+  date: 2017-11
   url: http://spire.sciencespo.fr/hdl:/2441/1ve2iilj4i94ip23o9iav2ja5b
   type: Articles
   source: Reset, (7), 1-1 (2017-11)
@@ -482,7 +482,7 @@
     - Crépel, Maxime
     - Jacomy, Mathieu
     - Boullier, Dominique
-  date: 2016, 1983
+  date: 2016
   url: http://spire.sciencespo.fr/hdl:/2441/3dciauig4s8g0rl470bucqrf33
   type: Articles
   source: Réseaux, 1(195), 131-161 (2016)
@@ -534,7 +534,7 @@
   authors:
     - Girard, Paul
     - Larousserie, David
-  date: 2012-02-03, 1944
+  date: 2012-02-03
   url: https://www.lemonde.fr/planete/article/2012/02/03/reseaux-la-quete-des-lois-du-web_1638035_3244.html
   type: Articles
   source: Le  (2012-02-03)
@@ -560,7 +560,7 @@
     - Venturini, Tommaso
     - Heymann, Sébastien
     - Bastian, Mathieu
-  date: 2014, 2006
+  date: 2014
   url: http://spire.sciencespo.fr/hdl:/2441/58bmf6rqp96hros64meac1fts
   type: Articles
   source: PLos ONE, 9(6), 1-18 (2014)
@@ -570,7 +570,7 @@
   title: "Explorer les internets avec Hyphe:METSEM #06"
   authors:
     - Jacomy, Mathieu
-  date: 2017-09-04, 2017-04
+  date: 2017-09-04
   url: https://metsem.hypotheses.org/111
   type: Communications orales
   source: null
@@ -595,7 +595,7 @@
     - Girard, Paul
     - Ooghe, Benjamin
     - Venturini, Tommaso
-  date: 2016-05, 2016-05-20
+  date: 2016-05
   url: http://www.aaai.org/ocs/index.php/ICWSM/ICWSM16/paper/view/13051/12797
   type: Communications avec actes
   source: International AAAI Conference on Web and Social Media, Köln, DE,
@@ -684,7 +684,7 @@
     - Jacomy, Mathieu
     - Girard, Paul
     - Plique, Guillaume
-  date: 2018-10, 2018-10
+  date: 2018-10
   url: http://hyphe.medialab.sciences-po.fr/docs/20181004-DigitalTools-HyperlinkIsNotDead.pdf
   type: Communications orales
   source: WS.2 2018 International conference on Web Studies, Paris, France — October
@@ -698,7 +698,7 @@
     - Venturini, Tommaso
     - Munk, Anders Kristian
     - Jacomy, Mathieu
-  date: 2016-01
+  date: 2016-01-01
   url: http://spire.sciencespo.fr/hdl:/2441/7jgmr11pjd939b8r7iobgqs53u
   type: Parties d'ouvrages
   source: "DigitalSTS: A Handbook and Fieldguide: Inconnu"
@@ -711,7 +711,7 @@
     - Jacomy, Mathieu
     - Baneyx, Audrey
     - Girard, Paul
-  date: 2016-05, 1983
+  date: 2016-05
   url: http://spire.sciencespo.fr/hdl:/2441/q9ro3ttpd9dbr4mml3st7996s
   type: Articles
   source: Réseaux, (199) (2016-05)

--- a/data/publications/elipss.yml
+++ b/data/publications/elipss.yml
@@ -71,7 +71,7 @@
     dans les enquêtes longitudinales par questionnaires
   authors:
     - Mercklé, Pierre
-  date: 7 avril 2017
+  date: 2017-04-07
   url: https://www.centre-max-weber.fr/Seminaire-Mensonges-et-statistiques
   type: Communications orales
   issue: null
@@ -89,7 +89,7 @@
     - Vincent, M.
     - Olivier, M.
     - Bonneterre, V.
-  date: 01/2015
+  date: 2015-01-01
   url: https://linkinghub.elsevier.com/retrieve/pii/S0761842514005269
   type: Articles
   issue: ""
@@ -331,7 +331,7 @@
     - Vincent, Michel
     - Olivier, Mathieu
     - Bonneterre, Vincent
-  date: 2015-01, 2015-01, 1887
+  date: 2015-01-01
   url: http://spire.sciencespo.fr/hdl:/2441/3c573noe08d09p9mrmpauqnkj
   type: Articles
   source: Revue des Maladies Respiratoires, 32(S), A155- (2015-01)
@@ -488,7 +488,7 @@
     - Danciu, Alina
     - Le Corgne, Simon
     - Mairot, Alexandre
-  date: 2015-12, 2015-12
+  date: 2015-12
   url: http://spire.sciencespo.fr/hdl:/2441/7rgf0vjfoh8v8br6g5hbmv47nf
   type: Communications orales
   source: 7th Annual European DDI User Conference (EDDI15), Copenhague, DK,

--- a/layouts/_default/publications.html
+++ b/layouts/_default/publications.html
@@ -17,7 +17,7 @@
     <section class="bibliography-section" id="{{$key}}-{{anchorize $type}}">
       <h3>{{ humanize (i18n (delimit (slice "mapping" $type) "_")) }}</h3>
 
-      {{ range . }}
+      {{ range (sort (sort . "title" "asc") "date" "desc") }}
       {{- $Publication := . -}}
       <article class="bibliography-entry bibliography-entry--quiet">
         <article class="bibliography-entry__body">

--- a/scripts/import/helpers.js
+++ b/scripts/import/helpers.js
@@ -39,3 +39,95 @@ export function cleanUrl (maybeUrl) {
     return maybeUrl;
   }
 }
+
+export const LANG_MAP = new Map([
+  ['décembre', 'december'],
+  ['decembre', 'december'],
+  ['novembre', 'november'],
+  ['octobre', 'october'],
+  ['septembre', 'september'],
+  ['août', 'august'],
+  ['aout', 'august'],
+  ['juillet', 'july'],
+  ['juin', 'june'],
+  ['mai', 'may'],
+  ['avril', 'april'],
+  ['mars', 'march'],
+  ['février', 'february'],
+  ['fevrier', 'february'],
+  ['janvier', 'january'],
+])
+export const MONTH_MAP = new Map([
+  ['12', 'december'],
+  ['11', 'november'],
+  ['10', 'october'],
+  ['09', 'september'],
+  ['08', 'august'],
+  ['07', 'july'],
+  ['06', 'june'],
+  ['05', 'may'],
+  ['04', 'april'],
+  ['03', 'march'],
+  ['02', 'february'],
+  ['01', 'january'],
+])
+
+const ALLOWED_TYPES = new Map([
+  ['year', 0],
+  ['month', 1],
+  ['day', 2],
+])
+
+export function cleanDate (string) {
+  return (string.match(/(\d{4}([\\/\-]\d{2}){0,2}(?=\s?[\/,][\s$])){1,2}/) || [])[0]
+  || string
+      .toLocaleLowerCase()
+      .replace(/^(\w+)\s(\d{4})/, (m, month, year) => `${year}-${[...MONTH_MAP].find(([key, value]) => value === month)[0]}`)
+      .replace(/^(\d{1,2})[\s\/\-](\d{4})/, (m, month, year) => `${year}-${month}`)
+      .replace(/^(\d{1,2})(-\d{1,2})? (\w+) (\d{4})/, (m, day, day2, month, year) => `${year}-${month}-${day}`)
+  || string;
+}
+
+export function translateDate (string) {
+  const lcString = string.toLocaleLowerCase()
+
+  for (const [fr, en] of LANG_MAP) {
+    if (lcString.includes(fr)) {
+      return lcString.replace(fr, en)
+    }
+  }
+
+  return string
+}
+
+export function matchMonth(dateString, value) {
+  return dateString.toLowerCase().match(new RegExp(`(^|\\D)(0?${Number(value)}|${MONTH_MAP.get(value)})(\\D|$)`));
+}
+
+export function matchDay(dateString, value) {
+  return dateString.match(new RegExp(`(^|\\D)0?${Number(value)}(\\D|$)`));
+}
+
+export function toDate (string) {
+  if (!string || typeof string !== 'string') {
+    return string
+  }
+
+  const formatter = new Intl.DateTimeFormat('fr-FR', {formatMatcher: 'basic', year: 'numeric', month: '2-digit', day: '2-digit'})
+  const dateString = translateDate(string);
+  const d = new Date(cleanDate(dateString));
+
+  if (Number.isNaN(d.getTime())) {
+    throw new RangeError(`La date [${string}] ne peut être convertie.`)
+  }
+
+  return formatter.formatToParts(d)
+    .filter(({type}) => ALLOWED_TYPES.has(type))
+    .sort((a, b) => ALLOWED_TYPES.get(a.type) - ALLOWED_TYPES.get(b.type))
+    .filter(({type, value}) => {
+      return dateString.match(new RegExp(`(^|\\D)${value}(\\D|$)`)) || (type === 'day' && matchDay(dateString, value)) || (type === 'month' && matchMonth(dateString, value))
+    })
+    .map(({value}) => value)
+    .join('-')
+    .toString();
+}

--- a/scripts/import/helpers.test.js
+++ b/scripts/import/helpers.test.js
@@ -1,5 +1,6 @@
 import test from 'ava';
-import {cleanUrl} from './helpers.js';
+import {cleanUrl, toDate, translateDate, cleanDate} from './helpers.js';
+
 
 test('cleanUrl() should prefix incomplete URL with http://', (t) => {
   t.deepEqual(cleanUrl('example.com/'), 'http://example.com/')
@@ -16,4 +17,35 @@ test('cleanUrl() should skip something which does not look like a URL', (t) => {
   t.deepEqual(cleanUrl('foo bar'), 'foo bar')
   t.deepEqual(cleanUrl(null), null)
   t.deepEqual(cleanUrl(undefined), undefined)
+})
+
+test('translateDate() translates FR strings into EN', (t) => {
+    t.deepEqual(translateDate('12 december 2014'), '12 december 2014')
+    t.deepEqual(translateDate('12 décembre 2014'), '12 december 2014')
+})
+
+test('cleanDate() prepares an invalid date', (t) => {
+  t.deepEqual(cleanDate('2018-10-03 / 2018-10-05'), '2018-10-03')
+  t.deepEqual(cleanDate('2016, 1983'), '2016')
+  t.deepEqual(cleanDate('2015-01, 2015-01, 1887'), '2015-01')
+  t.deepEqual(cleanDate('2012-02-03, 1944'), '2012-02-03')
+  t.deepEqual(cleanDate('12-13 décembre 2014'), '12-13 décembre 2014')
+  t.deepEqual(cleanDate('01/2015'), '2015-01')
+})
+
+test('toDate() should transform a string into a sortable date string', (t) => {
+    t.deepEqual(toDate(undefined), undefined)
+    t.deepEqual(toDate('12 décembre 2014'), '2014-12-12')
+    t.deepEqual(toDate('12-13 décembre 2014'), '2014-12-12')
+    t.deepEqual(toDate('January 1, 2019'), '2019-01-01')
+    t.deepEqual(toDate('2016/01/01'), '2016-01-01')
+    t.deepEqual(toDate('2016-05-12'), '2016-05-12')
+    t.deepEqual(toDate('2017'), '2017')
+    t.deepEqual(toDate('2016-12'), '2016-12')
+    t.deepEqual(toDate('May 2016'), '2016-05')
+    t.deepEqual(toDate('01/2015'), '2015-01-01')  // "bug", because month+day are equal
+    t.deepEqual(toDate('2018-10-03 / 2018-10-05'), '2018-10-03')
+    t.deepEqual(toDate('2016, 1983'), '2016')
+    t.deepEqual(toDate('2012-02-03, 1944'), '2012-02-03')
+    t.deepEqual(toDate('2014, 2006'), '2014')
 })

--- a/scripts/import/spire.js
+++ b/scripts/import/spire.js
@@ -1,6 +1,6 @@
 import {get} from 'superagent';
 import {decode} from 'he';
-import {getCategory, getDefaultCategory, cleanUrl} from './helpers.js';
+import {getCategory, getDefaultCategory, cleanUrl, toDate} from './helpers.js';
 import {parse} from 'fast-xml-parser';
 
 const getType = (type) => {
@@ -42,7 +42,7 @@ export default function importer (source, {publicationsMapping:mappingConfig, pu
           id,
           title: decode(title),
           authors: Array.isArray(authors) ? authors : [authors],
-          date: Array.isArray(date) ? date.join(', ') : date,
+          date: Array.isArray(date) ? toDate(date[0]) : toDate(date),
           url: cleanUrl(url),
           type,
           source,

--- a/scripts/import/zotero.js
+++ b/scripts/import/zotero.js
@@ -1,7 +1,7 @@
 import {debuglog} from 'util';
 import request from 'superagent';
 import {parse as parseLinkHeader} from 'http-link-header';
-import {getCategory, getDefaultCategory, cleanUrl} from './helpers.js';
+import {getCategory, getDefaultCategory, cleanUrl, toDate} from './helpers.js';
 
 const debug = debuglog('import:zotero');
 
@@ -57,7 +57,7 @@ export function parseBody (body, {publications, mappingConfig, publicationsLabel
       id,
       title,
       authors: getAuthors(creators),
-      date,
+      date: toDate(date),
       url: cleanUrl(url),
       type,
       issue,


### PR DESCRIPTION
> L'ordonnancement des résultats dans les sous-rubriques ne semble correspondre à aucune logique (en tout cas, nous ne sommes pas parvenu à l'identifier) : il faudrait s'assurer que dans chaque catégorie les résultats soit affichés dans un ordre antchronologique (le plus récent en haut) puis par ordre alphabétique du nom du premier auteur.