### PR TITLE
L'outil d'import Spire/Zotero est résilient aux erreurs de connec…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3401,6 +3401,11 @@
         }
       }
     },
+    "superagent-retry-delay": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/superagent-retry-delay/-/superagent-retry-delay-2.3.0.tgz",
+      "integrity": "sha512-QpLgurNwBew1lGCoIs3OXQ7krEV9D+/o+5a1LMaEQQht13EcygC46xB8iQpo+CPEGAsvNuLhST3yGZCri3sOug=="
+    },
     "supertap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supertap/-/supertap-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "lodash.intersection": "^4.4.0",
     "menuspy": "^1.3.0",
     "superagent": "^5.1.0",
+    "superagent-retry-delay": "^2.3.0",
     "tachyons-sass": "^4.9.5",
     "yaml": "^1.6.0"
   },

--- a/scripts/import/helpers.js
+++ b/scripts/import/helpers.js
@@ -1,4 +1,9 @@
 import intersect from 'lodash.intersection';
+import superagent from 'superagent';
+import extendWithDelay from 'superagent-retry-delay';
+
+extendWithDelay(superagent);
+export const get = superagent.get;
 
 export function getDefaultCategory (publications) {
   return Object.keys(publications).find(key => {

--- a/scripts/import/spire.js
+++ b/scripts/import/spire.js
@@ -1,6 +1,5 @@
-import {get} from 'superagent';
 import {decode} from 'he';
-import {getCategory, getDefaultCategory, cleanUrl, toDate} from './helpers.js';
+import {get, getCategory, getDefaultCategory, cleanUrl, toDate} from './helpers.js';
 import {parse} from 'fast-xml-parser';
 
 const getType = (type) => {
@@ -14,43 +13,46 @@ const getUrl = (urls) => {
     .pop();
 };
 
-export default function importer (source, {publicationsMapping:mappingConfig, publications, publicationsLabels}) {
+export function parseBody (text, {publications, publicationsMapping, publicationsLabels}) {
   const DEFAULT_CATEGORY = getDefaultCategory(publications);
+  const records = parse(text)['OAI-PMH'].ListRecords.record;
+
+  const items = records.map(item => {
+    const metadata = item.metadata['oai_dc:dc'];
+    const {identifier:id} = item.header;
+
+    const {['dc:title']:title, ['dc:date']:date, ['dc:creator']:authors} = metadata;
+    const {['dc:type']:types} = metadata;
+    const {['dc:publisher']:publication, ['dc:source']:source} = metadata;
+
+    const category = getCategory(item.header.setSpec, publications, 'spire');
+    const url = getUrl(metadata['dc:identifier']);
+
+    const itemType = getType(types.pop());
+    const type = publicationsMapping[itemType] || itemType;
+    if (publicationsLabels.indexOf(type) === -1) {
+      throw new RangeError(`[Import Spire] Le mapping '${type}' de l'item #${id} (${title}) est inconnu. Il est à configurer dans le fichier config.toml au niveau de l'ancre '[params.publicationsMapping.spire]'.`);
+    }
+
+    return {
+      id,
+      title: decode(title),
+      authors: Array.isArray(authors) ? authors : [authors],
+      date: Array.isArray(date) ? toDate(date[0]) : toDate(date),
+      url: cleanUrl(url),
+      type,
+      source,
+      publication,
+      category: category || DEFAULT_CATEGORY,
+    };
+  });
+
+  return {items, publications};
+}
+
+export default async function importer (source, {publicationsMapping:mappingConfig, publications, publicationsLabels}) {
   const {spire:publicationsMapping} = mappingConfig;
 
-  return get(source)
-    .then(({text}) => {
-      const records = parse(text)['OAI-PMH'].ListRecords.record;
-      const items = records.map(item => {
-        const metadata = item.metadata['oai_dc:dc'];
-        const {identifier:id} = item.header;
-
-        const {['dc:title']:title, ['dc:date']:date, ['dc:creator']:authors} = metadata;
-        const {['dc:type']:types} = metadata;
-        const {['dc:publisher']:publication, ['dc:source']:source} = metadata;
-
-        const category = getCategory(item.header.setSpec, publications, 'spire');
-        const url = getUrl(metadata['dc:identifier']);
-
-        const itemType = getType(types.pop());
-        const type = publicationsMapping[itemType] || itemType;
-        if (publicationsLabels.indexOf(type) === -1) {
-          throw new RangeError(`[Import Spire] Le mapping '${type}' de l'item #${id} (${title}) est inconnu. Il est à configurer dans le fichier config.toml au niveau de l'ancre '[params.publicationsMapping.spire]'.`);
-        }
-
-        return {
-          id,
-          title: decode(title),
-          authors: Array.isArray(authors) ? authors : [authors],
-          date: Array.isArray(date) ? toDate(date[0]) : toDate(date),
-          url: cleanUrl(url),
-          type,
-          source,
-          publication,
-          category: category || DEFAULT_CATEGORY,
-        };
-      });
-
-      return {items, publications};
-    })
+  const {text} = await get(source).retry(3, 5000);
+  return parseBody(text, {publications, publicationsLabels, publicationsMapping});
 };

--- a/scripts/import/zotero.js
+++ b/scripts/import/zotero.js
@@ -1,7 +1,6 @@
 import {debuglog} from 'util';
-import request from 'superagent';
 import {parse as parseLinkHeader} from 'http-link-header';
-import {getCategory, getDefaultCategory, cleanUrl, toDate} from './helpers.js';
+import {get, getCategory, getDefaultCategory, cleanUrl, toDate} from './helpers.js';
 
 const debug = debuglog('import:zotero');
 
@@ -26,7 +25,7 @@ const getSource = (data) => {
 
 export async function* paginate (url) {
   while (url) {
-    const {header, body} = await request.get(url);
+    const {header, body} = await get(url).retry(3, 5000);
     debug('paginating to %s', url);
 
     url = header.link && parseLinkHeader(header.link).rel('next').length


### PR DESCRIPTION
> (…) en cas de soucis dans la récupération de l'API, le script pourrait pusher un fichier vide sur Github et écraser les données pré-éxistantes par du rien. Ce serait bien qu'en cas d'erreur, on garde les anciennes données.

1. Lorsqu'une requête est faite, conserver les précédentes données si une requête n'aboutit pas ou qu'une erreur de traitement surgit.
1. Terminer le script avec un code d'erreur 1) si une collection n'est pas du tout récupérée (critique) ou 2) si une requête de pagination n'aboutit pas (temporaire)
1. Afficher le statut de mise à jour de chaque collection à la fin du script

Ça implique de ne plus appeler la tâche `npm run clean` et que la tâche soit idempotente, sans perte de données.
